### PR TITLE
Refactor Workers

### DIFF
--- a/apps/artemis/lib/artemis/cache/cache_instance.ex
+++ b/apps/artemis/lib/artemis/cache/cache_instance.ex
@@ -158,12 +158,7 @@ defmodule Artemis.CacheInstance do
   end
 
   def handle_call({:put, key, value}, _from, state) do
-    # Call the put function in a separate task to minimize potential memory
-    # growth in GenServer.
-    #
-    # See: https://elixirforum.com/t/extremely-high-memory-usage-in-genservers/4035/27
-    task = Task.async(fn -> Cachex.put(state.cachex_instance_name, key, value) end)
-    {:ok, _} = Task.await(task)
+    {:ok, _} = Cachex.put(state.cachex_instance_name, key, value)
 
     {:reply, value, state}
   end

--- a/apps/artemis/lib/artemis/workers/interval_worker.ex
+++ b/apps/artemis/lib/artemis/workers/interval_worker.ex
@@ -206,14 +206,7 @@ defmodule Artemis.IntervalWorker do
 
       defp update_state(state) do
         started_at = Timex.now()
-
-        # Call the update function in a separate task to minimize potential
-        # memory growth in GenServer.
-        #
-        # See: https://elixirforum.com/t/extremely-high-memory-usage-in-genservers/4035/27
-        task = Task.async(fn -> call(state.data, state.config) end)
-        result = Task.await(task)
-
+        result = call(state.data, state.config)
         ended_at = Timex.now()
 
         state

--- a/apps/artemis_log/lib/artemis_log/workers/interval_worker.ex
+++ b/apps/artemis_log/lib/artemis_log/workers/interval_worker.ex
@@ -206,14 +206,7 @@ defmodule ArtemisLog.IntervalWorker do
 
       defp update_state(state) do
         started_at = Timex.now()
-
-        # Call the update function in a separate task to minimize potential
-        # memory growth in GenServer.
-        #
-        # See: https://elixirforum.com/t/extremely-high-memory-usage-in-genservers/4035/27
-        task = Task.async(fn -> call(state.data, state.config) end)
-        result = Task.await(task)
-
+        result = call(state.data, state.config)
         ended_at = Timex.now()
 
         state


### PR DESCRIPTION
Remove `Task` optimization, which restricts what can be called inside the `call` function.