### PR TITLE
Prevent Cache Stampeding on Restart

### DIFF
--- a/apps/artemis/lib/artemis/context_cache.ex
+++ b/apps/artemis/lib/artemis/context_cache.ex
@@ -60,6 +60,26 @@ defmodule Artemis.ContextCache do
 
         Artemis.CacheInstance.fetch(__MODULE__, key, getter)
       rescue
+        error in MatchError -> handle_match_error(args, error)
+      end
+
+      defp handle_match_error(args, %MatchError{term: {:error, {:already_started, _}}}) do
+        # The CacheInstance contains two linked processes, a cache GenServer and a
+        # Cachex instance. The GenServer starts a linked Cachex instance on initialization.
+        #
+        # There is a race condition when the GenServer is started and the Cachex instance
+        # is still in the process of starting. If multiple requests are sent at
+        # the same time, it may result in multiple Cachex instances being started. The
+        # first instance to complete will succeed and all other requests will
+        # fail with an `:already_started` # error message.
+        #
+        # Since a Cachex instance is now running, resending the request to the
+        # GenServer will succeed.
+        #
+        fetch_cached(args)
+      end
+
+      defp handle_match_error(args, error) do
         # The CacheInstance contains two linked processes, a cache GenServer and a
         # Cachex instance. When a CacheInstance is reset, the cache GenServer is
         # stopped. Because they are linked, shortly after the Cachex instance is also
@@ -76,7 +96,8 @@ defmodule Artemis.ContextCache do
         # Instead of trying to resolve the race condition, let it crash. Return a valid
         # uncached result in the meantime. Future requests after this window closes will
         # successfully create a dynamic cache.
-        _ in MatchError -> %Artemis.CacheInstance.CacheEntry{data: apply(__MODULE__, :call, args)}
+        #
+        %Artemis.CacheInstance.CacheEntry{data: apply(__MODULE__, :call, args)}
       end
 
       defp create_cache() do

--- a/apps/artemis/lib/artemis/context_cache.ex
+++ b/apps/artemis/lib/artemis/context_cache.ex
@@ -79,7 +79,7 @@ defmodule Artemis.ContextCache do
         fetch_cached(args)
       end
 
-      defp handle_match_error(args, error) do
+      defp handle_match_error(args, _error) do
         # The CacheInstance contains two linked processes, a cache GenServer and a
         # Cachex instance. When a CacheInstance is reset, the cache GenServer is
         # stopped. Because they are linked, shortly after the Cachex instance is also


### PR DESCRIPTION
When the cache is empty, the first call to `fetch()` will execute the `getter` function and insert the result into the cache.

While the initial `getter` function is being evaluated but not yet completed, any additional calls to `fetch` will also see an empty cache and start executing the `getter` function. While inefficient, this duplication is especially problematic if the getter function is expensive or takes a long time to execute.

The GenServer can be used as a simple queuing mechanism to prevent this "thundering herd" scenario and ensure the `getter` function is only executed once.

Since all GenServer callbacks are blocking, any additional calls to the cache that are received while the `getter` function is being executed will be queued until after the initial call completes.

With the `getter` execution completed and the value stored in the cached, all subsequent calls in the queue can read directly from the cache.

Since the cache can support many different values under different keys, it's important to note the `fetch` function will never queue requests for keys that are already present in the cache. Only requests for keys that are currently empty will be queued.